### PR TITLE
Fix phoneme pulse post-processing

### DIFF
--- a/bm/features/basic.py
+++ b/bm/features/basic.py
@@ -69,7 +69,7 @@ class PhonemePulse(Feature):
 
         pulse_len = max(1, int(self.duration_ms * self.sample_rate / 1000))
         convert_to_pulse_count = 0
-        for i in range(samples_num - (pulse_len - 1)):
+        for i in range(samples_num):
             if convert_to_pulse_count > 0:
                 tensor[0, i] = 1
                 convert_to_pulse_count -= 1


### PR DESCRIPTION
## Summary
- fix phoneme pulse generation so that pulses at the end of the sequence are not truncated

## Testing
- `pytest bm/features/test_features.py::test_builder -q` *(fails: ModuleNotFoundError: No module named 'spacy')*

------
https://chatgpt.com/codex/tasks/task_e_68416db000a483258273bbb8031fb11b